### PR TITLE
proposal: add default reducer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,41 @@
 
 ## `mutableOn`
 
-The `mutableOn` function offers direct state mutations in reducers.
+Without the `mutableOn` function our `entityReducer` would look something like this.
+
+```ts
+const entityReducer = createReducer<{ entities: Record<number, { id: number; name: string }> }>(
+  {
+    entities: {},
+  },
+  on(create, (state, { type, ...entity }) => ({ 
+    ...state, 
+    entities: { ...state.entities, [entity.id]: entity }
+  }),
+  on(update, (state, { id, newName }) => {
+    const entity = state.entities[id]
+  
+    if (entity) {
+      return { 
+        ...state, 
+        entities: { 
+          ...state.entities, 
+          [entity.id]: { ...entity, name: newName } 
+        }
+      }
+    }
+    
+    return state;
+  },
+  on(remove, (state, { id }) => {
+    const { [id]: removedEntity, ...rest } = state.entities;
+    
+    return { ...state, entities: rest };
+  }),
+)
+```
+
+With the `mutableOn` function we are able to directly perform state mutations in reducers with less noise, and more concise code.
 
 ```ts
 const entityReducer = createReducer<{ entities: Record<number, { id: number; name: string }> }>(
@@ -18,7 +52,7 @@ const entityReducer = createReducer<{ entities: Record<number, { id: number; nam
       entity.name = newName
     }
   }),
-  mutableOn(deleete, (state, { id }) => {
+  mutableOn(remove, (state, { id }) => {
     delete state.entities[id]
   }),
 )


### PR DESCRIPTION
Personally I think it might be a good idea to show an example of how the reducer would be setup if you don't use `mutableOn` to show the advantages, because then I really shows the big advantage of not having all the boilerplate.